### PR TITLE
Add capability to pass an options object to the sort function instead…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4234,8 +4234,7 @@
     "moment": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
-      "dev": true
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/dariorinaldi/sort-everything/issues"
   },
   "homepage": "https://github.com/dariorinaldi/sort-everything#readme",
-  "dependencies":{
+  "dependencies": {
     "moment": "^2.22.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import moment from "moment";
+const DEFAULTS = { sortDir: "ASC", sortField: null, throwError: false };
 
-const OPTIONS = { sortDir: "ASC", sortField: null, throwError: false };
+const getOptions = options => {
+  return {
+    ...DEFAULTS,
+    ...options
+  };
+};
 
 const getType = val => {
   const type = typeof val;
@@ -82,7 +88,8 @@ const compare = (a, b, sortDir, sortField, throwError) => {
  * @param {boolean} options.handleError - If set to true in case of error returns the array sorted by the 0th element (or field in case of objects)
  * @return {Array.<any>} - The sorted array
  */
-const sort = (items, { sortDir, sortField, throwError } = OPTIONS) => {
+const sort = (items, options) => {
+  const { sortDir, sortField, throwError } = getOptions(options);
   return items.sort((a, b) => compare(a, b, sortDir, sortField, throwError));
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import moment from "moment";
 
+const OPTIONS = { sortDir: "ASC", sortField: null, throwError: false };
+
 const getType = val => {
   const type = typeof val;
   if (type === "string") {
@@ -72,14 +74,15 @@ const compare = (a, b, sortDir, sortField, throwError) => {
   return sortDir === "DESC" ? desc(itemA, itemB) : asc(itemA, itemB);
 };
 
-/** A function to sort an array in a type-aware mode 
-      /* @param {Array.<any>} items  - Array to sort. The items have to be of the same type
-      /* @param {string} sortDir  - Direction to sort to. It can be 'ASC' or 'DESC'
-      /* @param {string} sortField - In case of objects array, the field to use to sort
-      /* @param {boolean} handleError - If set to true in case of error returns the array sorted by the 0th element (or field in case of objects) 
-      /* @return {Array.<any>} - The sorted array
-      */
-const sort = (items, sortDir = "ASC", sortField = null, throwError = false) => {
+/** A function to sort an array in a type-aware mode
+ * @param {Array.<any>} items  - Array to sort. The items have to be of the same type
+ * @param {Object} options - Include options parameters to be used
+ * @param {string} options.sortDir  - Direction to sort to. It can be 'ASC' or 'DESC'
+ * @param {string} options.sortField - In case of objects array, the field to use to sort
+ * @param {boolean} options.handleError - If set to true in case of error returns the array sorted by the 0th element (or field in case of objects)
+ * @return {Array.<any>} - The sorted array
+ */
+const sort = (items, { sortDir, sortField, throwError } = OPTIONS) => {
   return items.sort((a, b) => compare(a, b, sortDir, sortField, throwError));
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ test("sort ascending", () => {
 });
 
 test("sort descending", () => {
-  expect(sort(items, "DESC")).toEqual([
+  expect(sort(items, { sortDir: "DESC" })).toEqual([
     { name: "mario" },
     { name: "luca" },
     { name: "andrea" }


### PR DESCRIPTION
Add capability to pass an options object to the sort function instead of a list of parameters.
This change can handle future changes.


Related: #1 